### PR TITLE
Update jquery.animateSprite.js

### DIFF
--- a/scripts/jquery.animateSprite.js
+++ b/scripts/jquery.animateSprite.js
@@ -16,13 +16,13 @@
             var discoverColumns = function (cb) {
                 var imageSrc = $this.css('background-image').replace(/url\((['"])?(.*?)\1\)/gi, '$2');
                 var image = new Image();
-                image.src = imageSrc;
 
                 image.onload = function () {
                     var width = image.width,
                         height = image.height;
                     cb(width, height);
                 };
+                image.src = imageSrc;
             };
 
             if (!data) {


### PR DESCRIPTION
Fix image onload on ie7/8.

It's caused because IE will cache the image, and the onload event will never fire after it's already been loaded.
